### PR TITLE
Add explicit POD encoding information

### DIFF
--- a/lib/Vitacilina.pm
+++ b/lib/Vitacilina.pm
@@ -1,5 +1,7 @@
 #!/usr/bin/env perl
 
+=encoding utf8
+
 =head1 NAME
 
 Vitacilina - ¡Ah, qué buena medicina!


### PR DESCRIPTION
As noticed by pod2man:

Around line 5:
 Non-ASCII character seen before =encoding in '¡Ah,'. Assuming UTF-8
